### PR TITLE
Three bug fixes

### DIFF
--- a/mandrill-wp-mail.php
+++ b/mandrill-wp-mail.php
@@ -28,7 +28,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'html'                       => $message,
 		'to'                         => $to,
 		'headers'                    => array(
-			'Content-type'           => 'text/plain',
+			'Content-type'           => apply_filters( 'wp_mail_content_type', 'text/plain' ),
 			),
 
 		// Mandrill defaults


### PR DESCRIPTION
- Use `site_url()` to generate the from address, which is more reliable.
- If the email was sent successfully, return true.
- Apply `wpautop()` to the body content if it's a plaintext email
