### PR TITLE
Fix the check for a 'text/plain' Content-Type header.

### DIFF
--- a/mandrill-wp-mail.php
+++ b/mandrill-wp-mail.php
@@ -106,7 +106,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	}
 
 	// Make sure our templates end up as HTML.
-	if ( ! empty( $message_args['headers']['Content-type'] ) && 'text/plain' === strtolower( $message_args['headers']['Content-type'] ) ) {
+	if ( ! empty( $message_args['headers']['Content-type'] ) && false !== strpos( strtolower( $message_args['headers']['Content-type'] ), 'text/plain' ) ) {
 		$message_args['html'] = wpautop( $message_args['html'] );
 	}
 


### PR DESCRIPTION
Jetpack, and other plugins, send the charset in the Content-Type  header,
causing the text/plain check to fail, so the message body doesn't get converted
to HTML.

Instead, just make sure the Content-Type header contains 'text/plain' at the
beginning of the string.

See #8