### PR TITLE
Parse args earlier

### DIFF
--- a/mandrill-wp-mail.php
+++ b/mandrill-wp-mail.php
@@ -81,17 +81,6 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'recipient_metadata'         => null,
 	);
 
-	// Set up message headers if we have any to send.
-	if ( ! empty( $headers ) ) {
-		$message_args = _mandrill_wp_mail_headers( $headers, $message_args );
-	}
-
-	if ( $message_args['headers']['Content-type'] === 'text/plain' ) {
-		$message_args['text'] = $message;
-	} else {
-		$message_args['html'] = $message;
-		$message_args['auto_text'] = true;
-	}
 	$message_args = apply_filters( 'mandrill_wp_mail_pre_message_args', $message_args );
 
 	// Make sure our to value is an array so we can manipulate it for the API.
@@ -109,6 +98,18 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		}
 	}
 	$message_args['to'] = $processed_to;
+
+	// Set up message headers if we have any to send.
+	if ( ! empty( $headers ) ) {
+		$message_args = _mandrill_wp_mail_headers( $headers, $message_args );
+	}
+
+	if ( $message_args['headers']['Content-type'] === 'text/plain' ) {
+		$message_args['text'] = $message;
+	} else {
+		$message_args['html'] = $message;
+		$message_args['auto_text'] = true;
+	}
 
 	// Default filters we should still apply.
 	$message_args['from_email'] = apply_filters( 'wp_mail_from', $message_args['from_email'] );

--- a/mandrill-wp-mail.php
+++ b/mandrill-wp-mail.php
@@ -28,7 +28,6 @@
  * @return bool true if mail has been sent, false if it failed
  */
 function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
-
 	// Return early if our API key hasn't been defined.
 	if ( ! defined( 'MANDRILL_API_KEY' ) ) {
 		return false;
@@ -124,8 +123,6 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 			'key'     => MANDRILL_API_KEY,
 		)
 	);
-
-	hm_log( $request_args );
 
 	$request_url = 'https://mandrillapp.com/api/1.0/messages/send.json';
 	$response = wp_remote_post( $request_url, $request_args );

--- a/mandrill-wp-mail.php
+++ b/mandrill-wp-mail.php
@@ -28,6 +28,7 @@
  * @return bool true if mail has been sent, false if it failed
  */
 function wp_mail( $to, $subject, $message, $headers = '', $attachments = array() ) {
+
 	// Return early if our API key hasn't been defined.
 	if ( ! defined( 'MANDRILL_API_KEY' ) ) {
 		return false;
@@ -81,6 +82,11 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'recipient_metadata'         => null,
 	);
 
+	// Set up message headers if we have any to send.
+	if ( ! empty( $headers ) ) {
+		$message_args = _mandrill_wp_mail_headers( $headers, $message_args );
+	}
+
 	if ( $message_args['headers']['Content-type'] === 'text/plain' ) {
 		$message_args['text'] = $message;
 	} else {
@@ -105,11 +111,6 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	}
 	$message_args['to'] = $processed_to;
 
-	// Set up message headers if we have any to send.
-	if ( ! empty( $headers ) ) {
-		$message_args = _mandrill_wp_mail_headers( $headers, $message_args );
-	}
-
 	// Default filters we should still apply.
 	$message_args['from_email'] = apply_filters( 'wp_mail_from', $message_args['from_email'] );
 	$message_args['from_name']  = apply_filters( 'wp_mail_from_name', $message_args['from_name'] );
@@ -123,6 +124,8 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 			'key'     => MANDRILL_API_KEY,
 		)
 	);
+
+	hm_log( $request_args );
 
 	$request_url = 'https://mandrillapp.com/api/1.0/messages/send.json';
 	$response = wp_remote_post( $request_url, $request_args );


### PR DESCRIPTION
I'm trying to send an HTML email, and its doing so by passing the content type as a header.

However - the args for html or plain text email content is set before we parse the headers passed to wp_mail.

Just need to move this a bit later. 

Also.. wat - accidentally committed this code from vagrant.
